### PR TITLE
use EXPECT_RANGE_EQ in cli test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # SeqAn3 App Template
 
-[![Build Status](https://travis-ci.com/joergi-w/app-template.svg?branch=master)](https://travis-ci.com/joergi-w/app-template)
+[![Build Status](https://travis-ci.com/seqan/app-template.svg?branch=master)](https://travis-ci.com/seqan/app-template)
 
 This is a template for app developers with SeqAn3. 
 You can easily clone this repository and modify the existing code to your needs. 
 It provides the elementary set-up for all SeqAn3 applications.
 
+The example application is a FastQ to FastA file format converter.
+It demonstrates exemplarily the set-up of test cases, documentation, and build infrastructure.
+Probably you want to name your app differently — simply replace `fastq_to_fasta` with your app name in the following.
+Please note that the command line interface tests fail if you use an individual project name without adapting the
+name in the test file.
+
 Instructions:
-1. clone this repository: `git clone --recurse-submodules https://github.com/joergi-w/app-template.git`
-2. create a build directory and visit it: `mkdir build && cd build`
-3. run cmake: `cmake ../app-template`
-4. build the application: `make`
-5. optional: build and run the tests: `make test`
-6. optional: build the api documentation: `make doc`
-7. execute the app: `./my_app`
+1. clone this repository: `git clone --recurse-submodules https://github.com/seqan/app-template.git fastq_to_fasta`
+2. edit the project name in the *project* command of `fastq_to_fasta/CMakeLists.txt`
+3. create a build directory and visit it: `mkdir build && cd build`
+4. run cmake: `cmake ../fastq_to_fasta`
+5. build the application: `make`
+6. optional: build and run the tests: `make test`
+7. optional: build the api documentation: `make doc`
+8. execute the app: `./fastq_to_fasta`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,7 @@ macro (add_app_test test_filename test_alternative)
     # Add the test to its general target (cli or api).
     if (${test_alternative} STREQUAL "CLI_TEST")
         add_dependencies (${target} "${PROJECT_NAME}") # cli test needs the application executable
-        target_include_directories(${target} PUBLIC "${SEQAN3_INCLUDE_DIR}/../test/include")
+        target_include_directories(${target} PUBLIC "${SEQAN3_CLONE_DIR}/test/include")
         add_dependencies (cli_test ${target})
     elseif (${test_alternative} STREQUAL "API_TEST")
         add_dependencies (api_test ${target})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ macro (add_app_test test_filename test_alternative)
     # Add the test to its general target (cli or api).
     if (${test_alternative} STREQUAL "CLI_TEST")
         add_dependencies (${target} "${PROJECT_NAME}") # cli test needs the application executable
+        target_include_directories(${target} PUBLIC "${SEQAN3_INCLUDE_DIR}/../test/include")
         add_dependencies (cli_test ${target})
     elseif (${test_alternative} STREQUAL "API_TEST")
         add_dependencies (api_test ${target})

--- a/test/cli/README.md
+++ b/test/cli/README.md
@@ -5,7 +5,9 @@ The test then validates whether the output is correct.
 
 Each test fixture should be inherited from the `cli_test` class: It provides the functionality of executing the app,
 finding the input files, capturing the output and creating individual test directories.
-The test output files are stored in the directory `test/output`
+We provide a new test macro `EXPECT_RANGE_EQ` for the comparison of whole ranges.
+It provides more insights about differences than an implementation with `EXPECT_TRUE(std::ranges::equal())`.
+The test output files are stored in the directory `test/output`.
 
 Attention: The default `make` target does not build tests.
 Please invoke the build with `make cli_test` or use `make test` to build and run all kinds of tests.

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -6,6 +6,8 @@
 #include <sstream>               // ostringstream
 #include <string>                // strings
 
+#include <seqan3/test/expect_range_eq.hpp> // EXPECT_RANGE_EQ macro
+
 #pragma once
 
 // Provides functions for CLI test implementation.

--- a/test/cli/cli_test.hpp
+++ b/test/cli/cli_test.hpp
@@ -6,7 +6,8 @@
 #include <sstream>               // ostringstream
 #include <string>                // strings
 
-#include <seqan3/test/expect_range_eq.hpp> // EXPECT_RANGE_EQ macro
+// Include the EXPECT_RANGE_EQ macro for better information if range elements differ.
+#include <seqan3/test/expect_range_eq.hpp>
 
 #pragma once
 

--- a/test/cli/fastq_to_fasta_options_test.cpp
+++ b/test/cli/fastq_to_fasta_options_test.cpp
@@ -62,7 +62,7 @@ TEST_F(cli_test, with_out_file)
     records.emplace_back("ACGTTTGATTCGCG"_dna5, std::string{"seq1"});
     records.emplace_back("TCGGGGGATTCGCG"_dna5, std::string{"seq2"});
 
-    EXPECT_TRUE(std::ranges::equal(fin, records));
+    EXPECT_RANGE_EQ(fin, records);
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, std::string{});
     EXPECT_EQ(result.err, std::string{});


### PR DESCRIPTION
This PR updates the SeqAn3 submodule and applies the EXPECT_RANGE_EQ macro in a command line interface test. 

This PR closes https://github.com/seqan/product_backlog/issues/4.