### PR TITLE
Make Release Default Built_Type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## BUILD
 
+# Make Release default build type
+if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE Release CACHE STRING
+         "Choose the type of build, options are: Debug Release RelWithDebInfo"
+         FORCE)
+endif ()
+
 # Specify the directories where to store the built archives, libraries and executables
 set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")


### PR DESCRIPTION
Make Default Built Type Release, so an user does not accidentally uses seqan3 in debug mode. ;)