### PR TITLE
[INFRA] Allows to configure googletest with the same top-level cmake flags.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,14 @@ add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
 add_definitions (-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
 add_definitions (-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
+# Define cmake configuration flags to configure and build external projects with the same flags as specified for
+# this project.
+set (APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS "")
+list (APPEND APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+list (APPEND APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+list (APPEND APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}")
+list (APPEND APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}")
+
 # Download and build Googletest module. The interface target 'gtest_all' contains all libs and header paths.
 message (STATUS "Configuring tests. Googletest will be downloaded on demand only.")
 include (cmake/build_googletest.cmake)

--- a/test/cmake/build_googletest.cmake
+++ b/test/cmake/build_googletest.cmake
@@ -1,5 +1,11 @@
 cmake_minimum_required (VERSION 3.8)
 
+# Set the project specific configuration settings to configure and build the gtest target.
+set (gtest_project_args ${APP_TEMPLATE_EXTERNAL_PROJECT_CMAKE_ARGS})
+
+# Force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`.
+list (APPEND gtest_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
+
 # Register how to download Googletest.
 include (ExternalProject)
 ExternalProject_Add (googletest
@@ -7,8 +13,11 @@ ExternalProject_Add (googletest
                      GIT_TAG           "master"
                      GIT_SHALLOW
                      PREFIX            "${CMAKE_CURRENT_BINARY_DIR}/googletest"
+                     CMAKE_ARGS        "${gtest_project_args}"
                      UPDATE_COMMAND    ""   # omit update step
                      INSTALL_COMMAND   "")  # do not install
+
+unset (gtest_project_args)
 
 # The 4 library targets of googletest are combined in the gtest_all interface.
 add_library (gtest_all INTERFACE)
@@ -16,12 +25,26 @@ ExternalProject_Get_Property (googletest binary_dir)
 foreach (target "gtest" "gmock" "gtest_main" "gmock_main")
     # Import the library from the googletest build directory.
     add_library (${target} UNKNOWN IMPORTED)
-    set_target_properties (${target} PROPERTIES
-                           IMPORTED_LOCATION "${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}${target}.a")
+
+    # Google test adds 'd' to its targets in debug build mode.
+    # This makes sure, that the target is linked against the correct compatible library.
+    set (target_suffix "")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set (target_suffix "d")
+    endif ()
+
+    # Define the proper target location.
+    set (target_location
+        "${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}${target}${target_suffix}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+    set_target_properties (${target} PROPERTIES IMPORTED_LOCATION "${target_location}")
     # Require googletest to be downloaded before the library is created.
     add_dependencies (${target} googletest)
     # Add the library to the 'gtest_all' interface target.
     target_link_libraries (gtest_all INTERFACE ${target})
+
+    unset (target_suffix)
+    unset (target_location)
 endforeach ()
 
 # Add the include directories to the 'gtest_all' interface target.


### PR DESCRIPTION
Changes:
* Link against google test targets with "d" suffix in the target name when building in debug mode.
* Use the same cmake flags to configure googletest as used for the project

These changes make sure that the google test target is configured and
built with the same flags as given to the top level cmake file.
This avoids some incompatibilities, e.g. that the
debug targets are not found by the test binaries,
when built in debug mode.