### PR TITLE
[INFRA] Update GitHub CI

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.4.1
         with:
-          workflow_id: 99999999 # GitHub ID for .github/workflows/ci.yml
+          workflow_id: ci.yml
           access_token: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # Push events to branches matching refs/heads/master
-      # - 'master'
+      - 'master'
   pull_request:
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SeqAn3 App Template
 
-[![Build Status](https://travis-ci.com/seqan/app-template.svg?branch=master)](https://travis-ci.com/seqan/app-template)
+[![Build Status](https://github.com/seqan/app-template/workflows/App%20CI/badge.svg)](https://github.com/seqan/app-template/actions?query=branch%3Amaster+workflow%3A%22App+CI%22)
 
 This is a template for app developers with SeqAn3. 
 You can easily clone this repository and modify the existing code to your needs. 


### PR DESCRIPTION
This is the follow-up for https://github.com/seqan/app-template/pull/34

I forgot that, for a few months now, you can use the workflow filename instead of the numeric ID. This is nice because you do not need to adjust it after cloning.